### PR TITLE
systemd: don't print out empty extinfo lines

### DIFF
--- a/plugins/system/systemd
+++ b/plugins/system/systemd
@@ -79,8 +79,10 @@ fetch () {
 				$states ; do
 				echo -n "$state.value "
 				grep $state$ $tmp | wc -l
-				echo -n "$state.extinfo "
-				echo $(grep $state$ $tmp | cut -d " " -f 1)
+				extinfo=`grep $state$ $tmp | cut -d " " -f 1`
+				if [ "$extinfo" ]; then
+					echo "$state.extinfo" $extinfo
+				fi
 			done
 			rm $tmp
 			;;


### PR DESCRIPTION
This fixes warnings like this in munin-update.log:

[WARNING] 4 lines had errors while 8 lines were correct (33.
33%) in data from 'fetch systemd'
