### PR TITLE
Fix remaining issues with systemd_units plugin

### DIFF
--- a/plugins/system/systemd_units
+++ b/plugins/system/systemd_units
@@ -61,15 +61,14 @@ EOF
 
 fetch () {
 	tmp=$(systemctl --no-pager --no-legend --all | awk '{print $1, $3}')
-	for state in \
-		$states ; do
-	echo -n "$state.value "
-	echo "$tmp" | grep -c "$state$"
-	extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1)
-	if [ -n "$extinfo" ]; then
-		echo "$state.extinfo" $extinfo
-	fi
-done
+	for state in $states ; do
+		echo -n "$state.value "
+		echo "$tmp" | grep -c "$state$"
+		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1)
+		if [ -n "$extinfo" ]; then
+			echo "$state.extinfo" $extinfo
+		fi
+	done
 }
 
 case $1 in

--- a/plugins/system/systemd_units
+++ b/plugins/system/systemd_units
@@ -64,7 +64,7 @@ fetch () {
 	for state in $states ; do
 		count=$(echo "$tmp" | grep -c "$state$")
 		echo "$state.value $count"
-		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1 | tr -d '\n')
+		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1 | tr '\n' ' ')
 		if [ -n "$extinfo" ]; then
 			echo "$state.extinfo" "$extinfo"
 		fi

--- a/plugins/system/systemd_units
+++ b/plugins/system/systemd_units
@@ -60,14 +60,12 @@ EOF
 }
 
 fetch () {
-	tmp=$(mktemp -t munin-systemd_units.XXXXXX)
-	trap "rm \"$tmp\"" EXIT
-	systemctl --no-pager --no-legend --all | awk '{print $1, $3}' > "$tmp"
+	tmp=$(systemctl --no-pager --no-legend --all | awk '{print $1, $3}')
 	for state in \
 		$states ; do
 	echo -n "$state.value "
-	grep -c "$state$" "$tmp"
-	extinfo=$(grep "$state$" "$tmp" | cut -d " " -f 1)
+	echo "$tmp" | grep -c "$state$"
+	extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1)
 	if [ -n "$extinfo" ]; then
 		echo "$state.extinfo" $extinfo
 	fi

--- a/plugins/system/systemd_units
+++ b/plugins/system/systemd_units
@@ -64,9 +64,9 @@ fetch () {
 	for state in $states ; do
 		count=$(echo "$tmp" | grep -c "$state$")
 		echo "$state.value $count"
-		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1)
+		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1 | tr -d '\n')
 		if [ -n "$extinfo" ]; then
-			echo "$state.extinfo" $extinfo
+			echo "$state.extinfo" "$extinfo"
 		fi
 	done
 }

--- a/plugins/system/systemd_units
+++ b/plugins/system/systemd_units
@@ -62,8 +62,8 @@ EOF
 fetch () {
 	tmp=$(systemctl --no-pager --no-legend --all | awk '{print $1, $3}')
 	for state in $states ; do
-		echo -n "$state.value "
-		echo "$tmp" | grep -c "$state$"
+		count=$(echo "$tmp" | grep -c "$state$")
+		echo "$state.value $count"
 		extinfo=$(echo "$tmp" | grep "$state$" | cut -d " " -f 1)
 		if [ -n "$extinfo" ]; then
 			echo "$state.extinfo" $extinfo


### PR DESCRIPTION
These changes fix remaining issues mentioned in this comment:

https://github.com/munin-monitoring/contrib/pull/744#issuecomment-256100097
- Avoid use of a temporary file,
- avoid use of `echo -n` flag,
- use `tr -d '\n'` instead of an unqouted variable to remove newlines from `$extinfo`.
